### PR TITLE
4 setup/sockets

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "bugs": {
     "url": "https://github.com/chas-academy/project-api-boilerplate/issues"
   },
-  "homepage":
-    "https://github.com/chas-academy/project-api-boilerplate/tree/master",
+  "homepage": "https://github.com/chas-academy/project-api-boilerplate/tree/master",
   "dependencies": {
     "bcrypt": "^1.0.3",
     "body-parser": "~1.0.1",
@@ -22,13 +21,15 @@
     "express-session": "^1.15.6",
     "mongoose": "^5.0.14",
     "passport": "^0.4.0",
-    "passport-local": "^1.0.0"
+    "passport-local": "^1.0.0",
+    "socket.io": "^2.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "jest": "^22.4.3",
-    "nodemon": "^1.12.1"
+    "nodemon": "^1.12.1",
+    "shortid": "^2.2.8"
   },
   "scripts": {
     "start": "nodemon --exec babel-node src/server.js",

--- a/src/server.js
+++ b/src/server.js
@@ -119,6 +119,15 @@ app.get("/:sessionId", (req, res) => {
   });
 });
 
+/* General client connection */
+io.on("connection", socket => {
+  /* Client emits what session they'd like to join */
+  socket.on("session", room => {
+    /* Add the client to this room */
+    socket.join(room);
+  });
+});
+
 /* Start */
 const port = process.env.PORT || 7770;
 app.listen(port, () => {

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,11 @@ import session from "express-session";
 import bodyParser from "body-parser";
 import cors from "cors";
 
+import http from "http";
+import socketIO from "socket.io";
+
+import shortid from "shortid";
+
 import mongoose from "mongoose";
 
 const dbActions = require("./db/actions");
@@ -16,6 +21,8 @@ if (!process.env.PORT) {
 
 /* App */
 const app = express();
+const server = http.Server(app);
+const io = socketIO(server);
 
 /* Middleware */
 app.use(
@@ -46,6 +53,8 @@ const db = mongoose.connection;
 
 /* Routes */
 app.get("/", (req, res) => res.send("Cobalt API"));
+
+/* Auth */
 app.post("/auth", passport.authenticate("local"), (req, res) => {
   res.json(200, {
     user: req.user
@@ -74,6 +83,40 @@ app.post("/user", (req, res) => {
         message: err.message
       })
     );
+});
+
+/* Socket IO */
+let rooms = {};
+
+/* Session URL */
+const getNewSession = sessionId => io.of(sessionId);
+
+app.post("/session", (req, res) => {
+  const sessionId = shortid.generate();
+
+  rooms[sessionId] = getNewSession(sessionId);
+
+  res.status(200).json({
+    success: true,
+    session: sessionId
+  });
+});
+
+/* Session Passthrough Route */
+app.get("/:sessionId", (req, res) => {
+  const { sessionId } = req.params;
+
+  if (!rooms[sessionId]) {
+    return res.status(404).json({
+      success: false,
+      message: "No session found for that URL."
+    });
+  }
+
+  res.status(200).json({
+    success: true,
+    session: sessionId
+  });
 });
 
 /* Start */


### PR DESCRIPTION
Added a helper module to generate short id's, might be a better idea to use something integrated with mongo later.

Added skeleton routes for creating and joining a session

`post('/session')` returns a new session ID for presenters to pass (saved in memory for now)
`get('/:sessionId')` checks if there's an ongoing session at the URL and returns true/false based on that. Returns the sessionId if the request was successful.